### PR TITLE
Allow consumers to inject env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-version

--- a/lib/cf-app-utils/cf/app/credentials.rb
+++ b/lib/cf-app-utils/cf/app/credentials.rb
@@ -1,20 +1,26 @@
 module CF::App
   class Credentials
-    class << self
+
+      attr_reader :service_service
+
+      def initialize(env)
+          @service_service = Service.new(env)
+      end
+
       # Returns credentials for the service instance with the given +name+.
       def find_by_service_name(name)
-        service = Service.find_by_name(name)
+        service = service_service.find_by_name(name)
         service['credentials'] if service
       end
 
       # Returns credentials for the first service instance with the given +tag+.
       def find_by_service_tag(tag)
-        service = Service.find_by_tag(tag)
+        service = service_service.find_by_tag(tag)
         service['credentials'] if service
       end
 
       def find_all_by_service_tag(tag)
-        services = Service.find_all_by_tag(tag)
+        services = service_service.find_all_by_tag(tag)
         services.map do |service|
           service['credentials']
         end
@@ -24,22 +30,25 @@ module CF::App
       def find_all_by_all_service_tags(tags)
         return [] if tags.empty?
 
-        Service.find_all_by_tags(tags).map { |service| service['credentials'] }
+        service_service.find_all_by_tags(tags).map { |service| service['credentials'] }
       end
 
       # Returns credentials for the first service instance with the given +label+.
       def find_by_service_label(label)
-        service = Service.find_by_label(label)
+        service = service_service.find_by_label(label)
         service['credentials'] if service
       end
 
       # Returns credentials for all service instances with the given +label+.
       def find_all_by_service_label(label)
-        services = Service.find_all_by_label(label)
+        services = service_service.find_all_by_label(label)
         services.map do |service|
           service['credentials']
         end
       end
-    end
+
+      def self.method_missing(message, *args, &block)
+          Credentials.new(ENV).public_send(message, *args, &block)
+      end
   end
 end

--- a/lib/cf-app-utils/cf/app/credentials.rb
+++ b/lib/cf-app-utils/cf/app/credentials.rb
@@ -1,54 +1,87 @@
 module CF::App
   class Credentials
-
-      attr_reader :service_service
-
-      def initialize(env)
-          @service_service = Service.new(env)
-      end
-
-      # Returns credentials for the service instance with the given +name+.
+    class << self
       def find_by_service_name(name)
-        service = service_service.find_by_name(name)
-        service['credentials'] if service
-      end
-
-      # Returns credentials for the first service instance with the given +tag+.
-      def find_by_service_tag(tag)
-        service = service_service.find_by_tag(tag)
-        service['credentials'] if service
+        credentials.find_by_service_name(name)
       end
 
       def find_all_by_service_tag(tag)
-        services = service_service.find_all_by_tag(tag)
-        services.map do |service|
-          service['credentials']
-        end
+        credentials.find_all_by_service_tag(tag)
       end
 
       # Returns credentials for the service instances with all the given +tags+.
       def find_all_by_all_service_tags(tags)
-        return [] if tags.empty?
+        credentials.find_all_by_all_service_tags(tags)
+      end
 
-        service_service.find_all_by_tags(tags).map { |service| service['credentials'] }
+      # Returns credentials for the first service instance with the given +tag+.
+      def find_by_service_tag(tag)
+        credentials.find_by_service_tag(tag)
       end
 
       # Returns credentials for the first service instance with the given +label+.
       def find_by_service_label(label)
-        service = service_service.find_by_label(label)
-        service['credentials'] if service
+        credentials.find_by_service_label(label)
       end
 
       # Returns credentials for all service instances with the given +label+.
       def find_all_by_service_label(label)
-        services = service_service.find_all_by_label(label)
-        services.map do |service|
-          service['credentials']
-        end
+        credentials.find_all_by_service_label(label)
       end
 
-      def self.method_missing(message, *args, &block)
-          Credentials.new(ENV).public_send(message, *args, &block)
+      def credentials
+        Credentials.new(ENV)
       end
+      private :credentials
+    end
+
+    def initialize(env)
+      @locator = Service.new(env)
+    end
+
+    # Returns credentials for the service instance with the given +name+.
+    def find_by_service_name(name)
+      service = locator.find_by_name(name)
+      service['credentials'] if service
+    end
+
+    # Returns credentials for the first service instance with the given +tag+.
+    def find_by_service_tag(tag)
+      service = locator.find_by_tag(tag)
+      service['credentials'] if service
+    end
+
+    def find_all_by_service_tag(tag)
+      services = locator.find_all_by_tag(tag)
+      services.map do |service|
+        service['credentials']
+      end
+    end
+
+    # Returns credentials for the service instances with all the given +tags+.
+    def find_all_by_all_service_tags(tags)
+      return [] if tags.empty?
+
+      locator.find_all_by_tags(tags).map { |service| service['credentials'] }
+    end
+
+    # Returns credentials for the first service instance with the given +label+.
+    def find_by_service_label(label)
+      service = locator.find_by_label(label)
+      service['credentials'] if service
+    end
+
+    # Returns credentials for all service instances with the given +label+.
+    def find_all_by_service_label(label)
+      services = locator.find_all_by_label(label)
+      services.map do |service|
+        service['credentials']
+      end
+    end
+
+    private
+
+    attr_reader :locator
+
   end
 end

--- a/lib/cf-app-utils/cf/app/service.rb
+++ b/lib/cf-app-utils/cf/app/service.rb
@@ -2,7 +2,10 @@ require 'json'
 
 module CF::App
   class Service #:nodoc:
-    class << self
+    def initialize(env = ENV)
+      @env = env
+    end
+
       def find_by_name(name)
         all.detect do |service|
           service['name'] == name
@@ -40,8 +43,7 @@ module CF::App
       private
 
       def all
-        @services ||= JSON.parse(ENV['VCAP_SERVICES']).values.flatten
+        @services ||= JSON.parse(@env['VCAP_SERVICES']).values.flatten
       end
-    end
   end
 end

--- a/spec/cf-app-utils/cf/app/credentials_spec.rb
+++ b/spec/cf-app-utils/cf/app/credentials_spec.rb
@@ -292,12 +292,12 @@ describe CF::App::Credentials do
         end
 
         describe CF::App::Credentials do
-            it 'allows users to inject their own env which is useful for testing' do
-                my_env = {}
-                vcap_services[cleardb_key][0]['credentials']['name'] = 'myname'
-                my_env['VCAP_SERVICES'] = JSON.dump(vcap_services)
-                expect(CF::App::Credentials.new(my_env).find_by_service_name('master-db')['name']).to eq('myname')
-            end
+          it 'allows users to inject their own env which is useful for testing' do
+            my_env = {}
+            vcap_services[cleardb_key][0]['credentials']['name'] = 'myname'
+            my_env['VCAP_SERVICES'] = JSON.dump(vcap_services)
+            expect(CF::App::Credentials.new(my_env).find_by_service_name('master-db')['name']).to eq('myname')
+          end
         end
       end
     end

--- a/spec/cf-app-utils/cf/app/credentials_spec.rb
+++ b/spec/cf-app-utils/cf/app/credentials_spec.rb
@@ -290,6 +290,15 @@ describe CF::App::Credentials do
                                                                                               ])
           end
         end
+
+        describe CF::App::Credentials do
+            it 'allows users to inject their own env which is useful for testing' do
+                my_env = {}
+                vcap_services[cleardb_key][0]['credentials']['name'] = 'myname'
+                my_env['VCAP_SERVICES'] = JSON.dump(vcap_services)
+                expect(CF::App::Credentials.new(my_env).find_by_service_name('master-db')['name']).to eq('myname')
+            end
+        end
       end
     end
   end


### PR DESCRIPTION
When I am writing tests expecting what comes out of my VCAP_SERVICES configuration, I'd rather not have to change the global ENV variable.  I'd rather be able to inject an ENV-like object.  This gives me more confidence that my code that interacts with Credentials behaves the way that I expect without changing the global environment.