### PR TITLE
Add environment setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ cleardb_url = credentials['uri']
 ```
 
 ```ruby
-# Inject your own environment variables
+# Inject your own environment variables for testing
 CF::App::Credentials.new(my_env)
 ```

--- a/README.md
+++ b/README.md
@@ -64,3 +64,44 @@ cleardb_url = credentials['uri']
 # Inject your own environment variables for testing
 CF::App::Credentials.new(my_env)
 ```
+
+## Environment
+
+12 Factor applications read their configuration from the environment. Applications that have not been designed for CF may be expecting configuration to exist in the environment at their own top level key (e.g. `CLOUDINARY_URL`). Rather than modifying an app to read from `VCAP_SERVICES` the `CF::App::Environment` class will set environment variables based on `VCAP_SERVICES` and configuration. 
+
+Example:
+
+```ruby
+configuration = [{ 
+ "name" => "CLOUDINARY_URL",
+ "method" => "name",
+ "parameter => "cloudinary",
+ "key" => "url"
+}]
+
+CF::App::Environment.set!(configuration)
+
+
+ `echo $CLOUDINARY_URL`
+
+ => "http://example.com"
+```
+
+alternatively, given a yaml file `env.yml`
+
+```yaml
+- name: TWITTER_OAUTH_TOKEN_SECRET
+  method: name
+  parameter: 'my-twitter'
+  key: 'TWITTER_OAUTH_TOKEN_SECRET'
+```
+
+```ruby
+CF::App:Environment.set_from_yaml!(env.yml)
+
+ `echo TWITTER_OAUTH_TOKEN_SECRET`
+
+ => "http://example.com"
+```
+
+Use with caution: This method will set actual environment variables.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Require and use the gem in your application:
 require 'cf-app-utils'
 ```
 
-You can then grab the credentials hash:
+## Credentials
+
+grabbing the credentials hash:
 
 ```ruby
 # Get credentials for the service instance with the given name

--- a/lib/cf-app-utils/cf.rb
+++ b/lib/cf-app-utils/cf.rb
@@ -1,4 +1,5 @@
 module CF end
 
 require 'cf-app-utils/cf/app/credentials'
+require 'cf-app-utils/cf/app/environment'
 require 'cf-app-utils/cf/app/service'

--- a/lib/cf-app-utils/cf/app/environment.rb
+++ b/lib/cf-app-utils/cf/app/environment.rb
@@ -1,0 +1,69 @@
+require 'yaml'
+
+module CF::App
+  class Environment
+    class Variable
+      attr_reader :name, :method, :parameter, :key
+
+      TYPES_TO_METHOD_NAMES = {
+        'label' => 'find_by_service_label',
+        'name' => 'find_by_service_name'
+      }
+
+      def initialize(options)
+        @name = options.fetch('name')
+        @method = options.fetch('method')
+        @parameter = options.fetch('parameter')
+        @key = options.fetch('key')
+      end
+
+      def derived_method
+        TYPES_TO_METHOD_NAMES.fetch(method)
+      end
+    end
+
+    class << self
+      def set!(*args)
+        environment.set!(*args)
+      end
+
+      def set_from_yaml!(*args)
+        environment.set_from_yaml!(*args)
+      end
+
+      def environment
+        Environment.new(ENV)
+      end
+
+      private :environment
+    end
+
+    def initialize(env)
+      @credentials = Credentials.new(env)
+      @env = env
+    end
+
+    def set!(*env_var_config)
+      env_var_config.flatten.each do |ev_config|
+        var = Variable.new(ev_config)
+        env[var.name] = credential_value(var)
+      end
+    end
+
+
+    def set_from_yaml!(yaml_file)
+      env_var_config = YAML.load_file(yaml_file)
+      set!(env_var_config)
+    end
+
+    private
+
+    def credential_value(var)
+      credential = credentials.public_send(var.derived_method, var.parameter)
+      raise KeyError unless credential
+      credential.fetch(var.key)
+    end
+
+    attr_reader :credentials, :env
+  end
+end

--- a/spec/cf-app-utils/cf/app/environment_spec.rb
+++ b/spec/cf-app-utils/cf/app/environment_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe CF::App::Environment do
+  let(:variables) { [ variable ] }
+
+  let(:vcap_services) do {
+    'user-provided'=> [
+      {
+        'credentials'=> {
+          'username'=> 'leroy-jenkins',
+          'password'=> 'hunter2'
+        },
+        'label'=> 'test-label',
+        'name'=> 'test-name',
+      }
+    ]
+  }
+  end
+
+  let(:env) { { "VCAP_SERVICES" => JSON.dump(vcap_services) } }
+
+  describe 'searching by label' do
+    let(:env_var_config) do {
+      'name' => 'USERNAME',
+      'method' => 'label',
+      'parameter' => 'test-label',
+      'key' => 'username'
+    }
+    end
+
+    it 'sets the USERNAME environment variable' do
+      described_class.new(env).set!(env_var_config)
+      expect(env['USERNAME']).to eq 'leroy-jenkins'
+    end
+  end
+
+  describe 'searching by name' do
+    let(:env_var_config) do {
+      'name' => 'PASSWORD',
+      'method' => 'name',
+      'parameter' => 'test-name',
+      'key' => 'password'
+    }
+    end
+
+    it 'sets the PASSWORD environment variable' do
+      described_class.new(env).set!(env_var_config)
+      expect(env['PASSWORD']).to eq 'hunter2'
+    end
+  end
+
+  describe 'error handling' do
+    describe "key values must exist" do
+      shared_examples_for "a method that requires keys that exist" do
+        context 'when the value is not found' do
+          let(:env_var_config) do {
+            'name' => 'PASSWORD',
+            'method' => 'name',
+            'parameter' => 'test-name',
+            'key' => 'password'
+          }
+          end
+
+          before do
+            env_var_config[key] = 'missing'
+          end
+
+          it 'raises a key not found error' do
+            expect { described_class.new(env).set!(env_var_config) }.to raise_error(KeyError)
+          end
+        end
+      end
+
+      context "when method is missing" do
+        let(:key) { 'method' }
+        it_behaves_like "a method that requires keys that exist"
+      end
+
+      context "when key is missing" do
+        let(:key) { 'key' }
+        it_behaves_like "a method that requires keys that exist"
+      end
+
+      context "when parameter is missing" do
+        let(:key) { 'parameter' }
+        it_behaves_like "a method that requires keys that exist"
+      end
+    end
+  end
+
+  describe "keys must exist" do
+    shared_examples_for "a method that requires keys" do
+      context 'when the value is not found' do
+        let(:env_var_config) do {
+          'name' => 'PASSWORD',
+          'method' => 'name',
+          'parameter' => 'test-name',
+          'key' => 'password'
+        }
+        end
+
+        before do
+          env_var_config.delete(key)
+        end
+
+        it 'raises a key not found error' do
+          expect { described_class.new(env).set!(env_var_config) }.to raise_error(KeyError, "key not found: \"#{key}\"")
+        end
+      end
+    end
+
+    context "when method is missing" do
+      let(:key) { 'method' }
+      it_behaves_like "a method that requires keys"
+    end
+
+    context "when key is missing" do
+      let(:key) { 'key' }
+      it_behaves_like "a method that requires keys"
+    end
+
+    context "when parameter is missing" do
+      let(:key) { 'parameter' }
+      it_behaves_like "a method that requires keys"
+    end
+  end
+end


### PR DESCRIPTION
This class adds the ability to set environment variables for legacy applications that aren't designed specifically for cloud foundry.

i.e. rather than replacing code that asks for CLOUDINARY_URL etc, use this as a shim to extract variables from VCAP_SERVICES and set the environment variable as required.
