### PR TITLE
Return no services if VCAP_SERVICES is missing

### DIFF
--- a/cf-app-utils.gemspec
+++ b/cf-app-utils.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*'] + ['LICENSE.txt', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3', '< 3.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 end

--- a/lib/cf-app-utils/cf/app/service.rb
+++ b/lib/cf-app-utils/cf/app/service.rb
@@ -43,7 +43,11 @@ module CF::App
       private
 
       def all
-        @services ||= JSON.parse(@env['VCAP_SERVICES']).values.flatten
+        @services ||= begin
+          JSON.parse(@env['VCAP_SERVICES']).values.flatten
+        rescue TypeError
+          []
+        end
       end
   end
 end

--- a/spec/cf-app-utils/cf/app/credentials_spec.rb
+++ b/spec/cf-app-utils/cf/app/credentials_spec.rb
@@ -302,6 +302,16 @@ describe CF::App::Credentials do
       end
     end
   end
+
+  describe 'for missing VCAP_SERVICES' do
+    before :each do
+      ENV['VCAP_SERVICES'] = nil
+    end
+
+    describe '.find_by_service_name' do
+      it 'returns nil' do
+        expect(CF::App::Credentials.find_by_service_name('empty-env-var')).to be_nil
+      end
+    end
+  end
 end
-
-


### PR DESCRIPTION
Previously, including `CF::App::Credentials.find_by_service_name` in a YAML config file would cause a TypeError unless `ENV["VCAP_SERVICES"]` is set to a valid JSON object. This isn't ideal when running in test or development environments where we wouldn't expect it to be set anyway.